### PR TITLE
Edit example to specify AWS runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ on:
 
 jobs:
   lint:
-    runs-on: [self-hosted, Linux]
+    runs-on: [self-hosted, Linux, AWS]
     timeout-minutes: 2
     steps:
       - name: Checkout


### PR DESCRIPTION
Selecting HQ runner is likely to run into docker rate limits